### PR TITLE
Include .well-known in Pages artifact

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,8 @@ jobs:
         if: github.event_name != 'pull_request'
         with:
           path: dist
+          # without this the artifact silently drops dist/.well-known
+          include-hidden-files: true
 
   deploy:
     if: github.event_name != 'pull_request'


### PR DESCRIPTION
upload-pages-artifact@v5 excludes dotfiles by default, so /.well-known/security.txt and /.well-known/discord 404'd on the live site. Sets include-hidden-files: true.